### PR TITLE
Vagrant file updated to handle bower

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,5 +17,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell", inline: "wget -qO- https://get.docker.com/ | sh"
   config.vm.provision "shell", inline: "gpasswd -a vagrant docker"
   config.vm.provision "shell", inline: "pip install -r /vagrant/requirements.txt"
+  config.vm.provision "shell", inline: "apt-get -y install nodejs npm"
+  config.vm.provision "shell", inline: "update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10"
+  config.vm.provision "shell", inline: "npm -g install bower"
+  config.vm.provision "shell", inline: "cd /vagrant/ui; bower install --allow-root --config.interactive=false;"
 
 end


### PR DESCRIPTION
Should be able to re-use this for the new, incoming UI but this installs node (properly (thanks Ubuntu!)), npm, bower and runs bower on the UI directory.