### PR TITLE
Added options for a container inbox and privileged execution on new containers

### DIFF
--- a/bakula/docker/dockeragent.py
+++ b/bakula/docker/dockeragent.py
@@ -6,6 +6,8 @@ import sys
 import time
 
 class DockerAgent(object):
+    CONTAINER_INBOX = '/inbox'
+
     def __init__(self, docker_base_url='unix://var/run/docker.sock', tls_config=False):
         self._docker_client = docker.Client(base_url=docker_base_url, tls=tls_config)
         self._containers = {}
@@ -31,7 +33,7 @@ class DockerAgent(object):
         container_name = self._create_container_name(image_name)
 
         # Create inbox volume for container
-        container_volumes_str = host_inbox + ":/inbox:rw"
+        container_volumes_str = '%s:%s:rw' % (host_inbox, DockerAgent.CONTAINER_INBOX)
 
         host_config_obj = self._docker_client.create_host_config(
             privileged=run_privileged,
@@ -41,7 +43,7 @@ class DockerAgent(object):
         container = self._docker_client.create_container(image=image_name,
                                                          name=container_name,
                                                          host_config=host_config_obj,
-                                                         volumes=['/inbox'],
+                                                         volumes=[DockerAgent.CONTAINER_INBOX],
                                                          command=command)
         container_id = container['Id']
         res = self._docker_client.start(container['Id'])

--- a/bakula/docker/dockeragent.py
+++ b/bakula/docker/dockeragent.py
@@ -6,16 +6,11 @@ import sys
 import time
 
 class DockerAgent(object):
-    def __init__(self, docker_base_url='unix://var/run/docker.sock',
-                 name_dict=None, should_update_dict=False):
-        self._docker_client = docker.Client(base_url=docker_base_url)
-        self._should_update_name__dict = should_update_dict
+    def __init__(self, docker_base_url='unix://var/run/docker.sock', tls_config=False):
+        self._docker_client = docker.Client(base_url=docker_base_url, tls=tls_config)
         self._containers = {}
-        if name_dict:
-            self._name_dict = name_dict
-        else:
-            self._name_dict = {}
-            self._update_container_indexes()
+        self._name_dict = {}
+        self._update_container_indexes()
 
     def build_image(self, path, image_name,
                     dockerfile='Dockerfile'):
@@ -27,36 +22,46 @@ class DockerAgent(object):
                 return True
         return False
 
-    def start_container(self, image_name, should_update_index=True, ports=None):
+    def start_container(self,
+                        image_name,
+                        host_inbox,
+                        ports=None,
+                        run_privileged=False,
+                        command=None):
         container_name = self._create_container_name(image_name)
-        print image_name
+
+        # Create inbox volume for container
+        container_volumes_str = host_inbox + ":/inbox:rw"
+
+        host_config_obj = self._docker_client.create_host_config(
+            privileged=run_privileged,
+            binds=[container_volumes_str],
+            port_bindings=ports
+        )
         container = self._docker_client.create_container(image=image_name,
-                                                         name=container_name)
+                                                         name=container_name,
+                                                         host_config=host_config_obj,
+                                                         volumes=['/inbox'],
+                                                         command=command)
         container_id = container['Id']
-        res = self._docker_client.start(container['Id'], port_bindings=ports)
-        print res
-        self._add_name_to_name_dict(image_name, container_name)
-        if should_update_index:
-            # Make sure our dictionary is fresh
-            self._update_container_indexes()
+        res = self._docker_client.start(container['Id'])
+        # Make sure our dictionary is fresh
+        self._update_container_indexes()
         return container_id
 
-    def stop_container(self, container_name, should_update_index=True):
+    def stop_container(self, container_name):
         container_id = self._containers[container_name]
         self._docker_client.stop(container=container_id, timeout=5)
         time.sleep(5)
         self._docker_client.remove_container(container=container_id, v=True,
                                              force=True)
-        if should_update_index:
-            self._update_container_indexes()
+        self._update_container_indexes()
 
 
-    def stop_all_containers_of_image(self, image_name, should_update_index=True):
+    def stop_all_containers_of_image(self, image_name):
         for container_name in self._name_dict[image_name]:
             self.stop_container(container_name, False)
-
-        if should_update_index:
-            self._update_container_indexes()
+        self._update_container_indexes()
 
     def get_port_info_for_container(self, container_id, port):
         return self._docker_client.port(container_id, port)
@@ -77,7 +82,6 @@ class DockerAgent(object):
     def _create_container_name(self, image_name):
         nin = self._normalize_image_name(image_name)
         # New image being inserted
-        print image_name
         if image_name not in self._name_dict:
             container_name = '%s_%d' % (nin, 0)
             return container_name
@@ -106,6 +110,7 @@ class DockerAgent(object):
     def _normalize_image_name(self, image_name):
         image_name = image_name.replace('/', '_')
         image_name = image_name.replace('-', '_')
+        image_name = image_name.replace(':', '_')
         return image_name
 
     def _add_name_to_name_dict(self, image_name, name):

--- a/bakula/docker/dockeragent.py
+++ b/bakula/docker/dockeragent.py
@@ -7,6 +7,7 @@ import time
 
 class DockerAgent(object):
     CONTAINER_INBOX = '/inbox'
+    NAME_CHARS_TO_REPLACE = ['/', '-', ':']
 
     def __init__(self, docker_base_url='unix://var/run/docker.sock', tls_config=False):
         self._docker_client = docker.Client(base_url=docker_base_url, tls=tls_config)
@@ -110,9 +111,8 @@ class DockerAgent(object):
 
 
     def _normalize_image_name(self, image_name):
-        image_name = image_name.replace('/', '_')
-        image_name = image_name.replace('-', '_')
-        image_name = image_name.replace(':', '_')
+        for char in DockerAgent.NAME_CHARS_TO_REPLACE:
+            image_name = image_name.replace(char, '_')
         return image_name
 
     def _add_name_to_name_dict(self, image_name, name):

--- a/bakula/events/eventhandler.py
+++ b/bakula/events/eventhandler.py
@@ -39,12 +39,12 @@ class EventHandler:
         event_type = event_json['event_type']
         event_key = event_json['event_key']
         key = self._get_key(event_type, event_key)
-	print key
-	if not key in self.events_to_images:
-		return
+        print key
+        if not key in self.events_to_images:
+            return
         images = self.events_to_images[key]
         for image in images:
-       	    container_url = self.get_url_for_image(image)
+            container_url = self.get_url_for_image(image)
             # Start a container
             if not container_url:
                 container_url = self._start_container(image)


### PR DESCRIPTION
I added options to the start_container method for starting a container in privileged mode, and also added a command in there as well (we don't need to do anything with this for now, but it helped with testing and might be useful if we want to reuse images for different things).

I also added a ```tls_config``` option to the DockerAgent class because I'm using docker-machine locally, which uses TLS.

A lot of the methods had a ```should_update_index``` flag that wasn't really being used anywhere (couldn't find any references in the project) so I got rid of it. There isn't a lot of overhead with grabbing everything from the docker agent so it's probably fine (and safest) to update always.

Reformatted one of the files that had a couple tab characters in it.

@KrisSiegel @sapanshah 

Resolves #21.