### PR TITLE
Inboxer events

### DIFF
--- a/bakula/events/inboxer_test.py
+++ b/bakula/events/inboxer_test.py
@@ -11,6 +11,24 @@ class InboxerTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(".tmp", ignore_errors=True)
 
+    def test_on(self):
+        def callback(data):
+            self.assertEqual(data["topic"], "MyTopicEvent")
+
+        master_inbox_path = os.path.join(".tmp", "master_inbox")
+        container_inboxes_path = os.path.join(".tmp", "container_inboxes")
+        testfile = os.path.join(".tmp", "testFile.json")
+
+        # Initialize inboxer using a tmp directory for unit testing
+        inboxer = Inboxer(master_inbox_path, container_inboxes_path)
+
+        inboxer.on("received", callback)
+        # Create our test file
+        with open(testfile, "a"):
+            os.utime(testfile, None)
+
+        counter = inboxer.add_file_by_path("MyTopicEvent", testfile)
+
     def test_add_file_by_path(self):
         master_inbox_path = os.path.join(".tmp", "master_inbox")
         container_inboxes_path = os.path.join(".tmp", "container_inboxes")


### PR DESCRIPTION
This adds the ability to handle events within the Inboxer (currently only a received event). This is necessary to support #18.

*Note*: This should not be merged until #30 as this branch is based on that PR's branch (and thusly includes all of its changes). This also means you can ignore all change files except the ./events/inboxer.py and ./events/inboxer_test.py until #18 is merged.

@sapanshah @ericjperry 