### PR TITLE
Fix some stuffs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Install all the needed packages
   config.vm.provision "shell", inline: "apt-get update"
-  config.vm.provision "shell", inline: "apt-get -y install python-pip python-dev"
+  config.vm.provision "shell", inline: "apt-get -y install python-pip python-dev libffi-dev"
   config.vm.provision "shell", inline: "wget -qO- https://get.docker.com/ | sh"
   config.vm.provision "shell", inline: "gpasswd -a vagrant docker"
   config.vm.provision "shell", inline: "pip install -r /vagrant/requirements.txt"

--- a/bakula/events/inboxer.py
+++ b/bakula/events/inboxer.py
@@ -16,7 +16,7 @@
 #   under the License.
 
 import os
-from atomic import AtomicLong
+from atomiclong import AtomicLong
 
 # class Inboxer provides basic capabilities to put a file in the master inbox,
 # create a hardlink to that file in the correct container inboxes path and then

--- a/bakula/services/event.py
+++ b/bakula/services/event.py
@@ -15,7 +15,7 @@ from bottle import Bottle, HTTPResponse, request, response, FileUpload
 from bakula.bottle import configuration
 from bakula.bottle.errorutils import create_error
 from bakula.events.inboxer import Inboxer
-from atomic import AtomicLong
+from atomiclong import AtomicLong
 
 app = Bottle()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docker-py
-atomic
+atomiclong
 bottle
 peewee
 webtest


### PR DESCRIPTION
So @ericjperry and I were running into some issues with the library ```atomic```. After some investigation I found two things.

First, the vagrant machine was failing to build due to missing libffi (I think this was related to bcrypt so not really related but the fix is going in here anyway)

Second, we both kept getting permission denied into some directories the atomic library was using. So I switched to using a different one which seems to work for me.

@sapanshah @ericjperry 