### PR TITLE
Added endpoint for retrieving available docker image names

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -18,7 +18,7 @@ import argparse
 import sys
 
 from bottle import Bottle, run
-from bakula.services import healthcheck, registration, event, user
+from bakula.services import healthcheck, registration, event, user, docker
 from bakula.models import initialize_models
 from bakula.bottle import configuration
 
@@ -30,7 +30,8 @@ sub_apps = [
     healthcheck.app,
     registration.app,
     user.app,
-    event.app
+    event.app,
+    docker.app
 ]
 
 if __name__ == '__main__':

--- a/bakula/services/docker.py
+++ b/bakula/services/docker.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing,
+#   software distributed under the License is distributed on an
+#   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#   KIND, either express or implied.  See the License for the
+#   specific language governing permissions and limitations
+#   under the License.
+
+from bottle import Bottle, request
+from bakula.bottle import configuration
+from bakula.bottle.errorutils import create_error
+from bakula.security.tokenauthplugin import TokenAuthorizationPlugin
+import requests
+import urlparse
+
+app = Bottle()
+
+configuration.bootstrap_app_config(app)
+
+# Setup authorization plugin
+token_secret = app.config.get('token_secret', 'password')
+auth_plugin = TokenAuthorizationPlugin(token_secret)
+app.install(auth_plugin)
+
+# Set up connection defaults
+auth = (app.config.get('registry_username'), app.config.get('registry_password'))
+base_url = app.config.get('registry_url', 'https://registry.immuta.com/v1/')
+
+@app.get('/images')
+def get_images():
+    response = requests.get(urlparse.urljoin(base_url, 'search'))
+    response_obj = response.json()
+    image_names = map(lambda image: image['name'], response_obj['results'])
+    return {'images': image_names}

--- a/bakula/services/docker.py
+++ b/bakula/services/docker.py
@@ -32,9 +32,9 @@ auth_plugin = TokenAuthorizationPlugin(token_secret)
 app.install(auth_plugin)
 
 # Set up connection defaults
-auth = (app.config.get('registry_username'), app.config.get('registry_password'))
-registry_host = app.config.get('registry_host', 'registry.immuta.com')
-protocol = app.config.get('registry_protocol', 'https')
+auth = (app.config.get('registry.username'), app.config.get('registry.password'))
+registry_host = app.config.get('registry.host', 'registry.immuta.com')
+protocol = app.config.get('registry.protocol', 'https')
 base_url = urlparse.urljoin('://'.join([protocol, registry_host]), 'v1/')
 
 # Helper method for getting the image name from the docker registry response. Prepends
@@ -48,7 +48,10 @@ def get_image_name(image):
 
 @app.get('/images')
 def get_images():
-    response = requests.get(urlparse.urljoin(base_url, 'search'), auth=auth)
+    params = {}
+    if 'query' in request.query:
+        params['q'] = request.query['query']
+    response = requests.get(urlparse.urljoin(base_url, 'search'), auth=auth, params=params)
     response_obj = response.json()
     image_names = map(get_image_name, response_obj['results'])
     return {'images': image_names}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ webtest
 simplejson
 itsdangerous
 py-bcrypt
+requests
+


### PR DESCRIPTION
Added an ```/images``` endpoint which retrieves all available images from the configured docker registry, or runs a query against the registry if the 'query' parameter is provided.

Right now there's no default registry, and we could potentially make the docker hub the default registry, but it would involve a little bit more work. Happy to do that with this PR but @sapanshah previously said we didn't need to worry about that yet. This will also require credentials to our private docker registry, which I'll send to you guys via email.

@KrisSiegel @sapanshah 

Resolves #37 