### PR TITLE
Updated registration model with threshold, timeout, and privileged flag

### DIFF
--- a/bakula/models.py
+++ b/bakula/models.py
@@ -14,7 +14,7 @@
 #   KIND, either express or implied.  See the License for the
 #   specific language governing permissions and limitations
 #   under the License.
-from peewee import Proxy, Model, CharField, ForeignKeyField
+from peewee import Proxy, Model, CharField, ForeignKeyField, IntegerField, BooleanField
 from bakula.bottle import peeweeutils
 
 db = Proxy()
@@ -30,6 +30,9 @@ class User(BaseModel):
 class Registration(BaseModel):
     topic = CharField()
     container = CharField()
+    privileged = BooleanField(default=False)
+    threshold = IntegerField(default=0)
+    timeout = IntegerField(default=0)
     creator = ForeignKeyField(User)
 
     class Meta:

--- a/bakula/models_test.py
+++ b/bakula/models_test.py
@@ -31,7 +31,7 @@ class ModelsTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        peeweeutils.get_db_from_config({'sqlite_database': ':memory:', 'databaseType': 'sqlite'}, test_db)
+        peeweeutils.get_db_from_config({'database.name': ':memory:', 'database.type': 'sqlite'}, test_db)
         TestModel.create_table()
         obj = TestModel(name='test', message='this is a test model')
         obj.save()
@@ -48,7 +48,7 @@ class ModelsTest(unittest.TestCase):
         self.assertEqual(results[0]['name'], 'test')
 
     def test_initialize_models(self):
-        models.initialize_models({'sqlite_database': ':memory:', 'databaseType': 'sqlite'})
+        models.initialize_models({'database.name': ':memory:', 'database.type': 'sqlite'})
         self.assertTrue(models.Registration.table_exists())
         self.assertTrue(models.User.table_exists())
 

--- a/bakula/services/registration_test.py
+++ b/bakula/services/registration_test.py
@@ -29,7 +29,7 @@ class RegistrationTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
-        models.initialize_models({'sqlite_database': ':memory:', 'databaseType': 'sqlite'})
+        models.initialize_models({'database.name': ':memory:', 'database.type': 'sqlite'})
         iam.create('user', 'some_password')
         RegistrationTest.test_user = models.User.get(models.User.id == 'user')
         RegistrationTest.auth_header = {'Authorization': tokenutils.generate_auth_token('password', RegistrationTest.test_user.id, 120)}
@@ -49,6 +49,9 @@ class RegistrationTest(unittest.TestCase):
         from_db = models.Registration.get(models.Registration.id == 1)
         self.assertIsNotNone(from_db)
         self.assertEquals(from_db.topic, topic)
+        self.assertEquals(from_db.threshold, 0)
+        self.assertEquals(from_db.timeout, 0)
+        self.assertFalse(from_db.privileged)
 
     def test_create_registration_already_exists(self):
         topic = 'test'

--- a/bakula/services/user_test.py
+++ b/bakula/services/user_test.py
@@ -28,7 +28,7 @@ class UserTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         UserTest.test_token = tokenutils.generate_auth_token('password', 'admin', 60)
-        models.initialize_models({'sqlite_database': ':memory:', 'databaseType': 'sqlite'})
+        models.initialize_models({'database.name': ':memory:', 'database.type': 'sqlite'})
 
     def setUp(self):
         models.User.delete().execute()


### PR DESCRIPTION
@sapanshah @KrisSiegel 

This also fixes some of the tests that had the old configuration format.

Resolves #43.