### PR TITLE
Orchestrator threshold and timeout

### DIFF
--- a/bakula/events/inboxer.py
+++ b/bakula/events/inboxer.py
@@ -46,13 +46,12 @@ class Inboxer(object):
                 self.event_subscriptions[event] is not None):
             self.event_subscriptions[event](data)
 
+    # Looks at the file system and gathers the current count by specified topic
     def __get_file_count(self, topic):
         master_topic_path = os.path.join(self.master_inbox_path, topic)
         count = 0
         if os.path.exists(master_topic_path):
-            for dirname, subdirs, files in os.walk(master_topic_path):
-                for fname in files:
-                    count = count + 1
+            count = len([fname for fname in os.listdir(master_topic_path) if os.path.isfile(os.path.join(master_topic_path, fname))])
 
         return count
 

--- a/bakula/events/inboxer.py
+++ b/bakula/events/inboxer.py
@@ -32,7 +32,7 @@ class Inboxer(object):
         self.container_inboxes_path = container_inboxes_path
         self.atomic_counter = atomic_counter
         self.event_subscriptions = {} # Keep callbacks for events subscribed to
-        self.countCache = {} # Keep a cache of file counts; faster than recounting
+        self.count_cache = {} # Keep a cache of file counts; faster than recounting
 
         if not os.path.exists(self.master_inbox_path):
             os.makedirs(self.master_inbox_path)
@@ -58,16 +58,16 @@ class Inboxer(object):
 
     # Get a count from the cache count
     def __get_count_cache(self, topic):
-        if topic not in self.countCache:
-            self.countCache[topic] = __get_file_count(topic)
-        return self.countCache[topic]
+        if topic not in self.count_cache:
+            self.count_cache[topic] = __get_file_count(topic)
+        return self.count_cache[topic]
 
     # Update the count cache
     def __update_count_cache(self, topic, count=None):
         if count is None:
-            self.countCache[topic] = self.__get_file_count(topic)
+            self.count_cache[topic] = self.__get_file_count(topic)
         else:
-            self.countCache[topic] = count
+            self.count_cache[topic] = count
 
     # Registers a callback for a specific event
     # Don't care to support multiple registrations per event. Right now at

--- a/bakula/events/inboxer.py
+++ b/bakula/events/inboxer.py
@@ -31,7 +31,8 @@ class Inboxer:
         self.master_inbox_path = master_inbox_path
         self.container_inboxes_path = container_inboxes_path
         self.atomic_counter = atomic_counter
-        self.event_subscriptions = {}
+        self.event_subscriptions = {} # Keep callbacks for events subscribed to
+        self.countCache = {} # Keep a cache of file counts; faster than recounting
 
         if not os.path.exists(self.master_inbox_path):
             os.makedirs(self.master_inbox_path)
@@ -39,10 +40,34 @@ class Inboxer:
         if not os.path.exists(self.container_inboxes_path):
             os.makedirs(self.container_inboxes_path)
 
+    # This method is called to trigger an event
     def __trigger_event_subscription(self, event, data=None):
         if (event in self.event_subscriptions and
                 self.event_subscriptions[event] is not None):
             self.event_subscriptions[event](data)
+
+    def __get_file_count(self, topic):
+        master_topic_path = os.path.join(self.master_inbox_path, topic)
+        count = 0
+        if os.path.exists(master_topic_path):
+            for dirname, subdirs, files in os.walk(master_topic_path):
+                for fname in files:
+                    count = count + 1
+
+        return count
+
+    # Get a count from the cache count
+    def __get_count_cache(self, topic):
+        if topic not in self.countCache:
+            self.countCache[topic] = __get_file_count(topic)
+        return self.countCache[topic]
+
+    # Update the count cache
+    def __update_count_cache(self, topic, count=None):
+        if count is None:
+            self.countCache[topic] = self.__get_file_count(topic)
+        else:
+            self.countCache[topic] = count
 
     # Registers a callback for a specific event
     # Don't care to support multiple registrations per event. Right now at
@@ -69,6 +94,7 @@ class Inboxer:
                 print "Writing to master inbox failed due to %s" % ex
                 return None
 
+        self.__update_count_cache(topic)
         self.__trigger_event_subscription("received", {"topic": topic})
         return counter
 
@@ -91,6 +117,7 @@ class Inboxer:
                 print "Writing to master inbox failed due to %s" % ex
                 return None
 
+        self.__update_count_cache(topic)
         self.__trigger_event_subscription("received", {"topic": topic})
         return counter
 
@@ -105,6 +132,10 @@ class Inboxer:
                     result.append(fname)
 
         return result
+
+    # Get a count of files in the master inbox for a specific topic
+    def get_inbox_count(self, topic):
+        return self.__get_count_cache(topic)
 
     # Promotes a file from the master inbox into a container inbox delineated
     # by container id
@@ -150,4 +181,5 @@ class Inboxer:
                 else:
                     print "Failure creating hard link on %s" % fullpath
 
+            self.__update_count_cache(topic)
             return container_inboxes

--- a/bakula/events/inboxer.py
+++ b/bakula/events/inboxer.py
@@ -21,7 +21,7 @@ from atomiclong import AtomicLong
 # class Inboxer provides basic capabilities to put a file in the master inbox,
 # create a hardlink to that file in the correct container inboxes path and then
 # delete the original file in the master inbox.
-class Inboxer:
+class Inboxer(object):
     # Initialize class with default paths to the master inbox and container
     # inboxes
     def __init__(self,

--- a/bakula/events/inboxer_test.py
+++ b/bakula/events/inboxer_test.py
@@ -108,6 +108,32 @@ class InboxerTest(unittest.TestCase):
 
         self.assertEqual(len(inboxer.get_inbox_list("MyTopic")), 3)
 
+    def test_get_inbox_count(self):
+        master_inbox_path = os.path.join(self.TEST_DIR, "master_inbox")
+        container_inboxes_path = os.path.join(self.TEST_DIR, "container_inboxes")
+        testfile1 = os.path.join(self.TEST_DIR, "testFile1.json")
+        testfile2 = os.path.join(self.TEST_DIR, "testFile2.json")
+        testfile3 = os.path.join(self.TEST_DIR, "testFile3.json")
+
+        # Initialize inboxer using a tmp directory for unit testing
+        inboxer = Inboxer(master_inbox_path, container_inboxes_path)
+
+        # Create our test files
+        with open(testfile1, "a"):
+            os.utime(testfile1, None)
+
+        with open(testfile2, "a"):
+            os.utime(testfile2, None)
+
+        with open(testfile3, "a"):
+            os.utime(testfile3, None)
+
+        inboxer.add_file_by_path("MyTopic", testfile1)
+        inboxer.add_file_by_path("MyTopic", testfile2)
+        inboxer.add_file_by_path("MyTopic", testfile3)
+
+        self.assertEqual(inboxer.get_inbox_count("MyTopic"), 3)
+
     def test_promote_to_container_inbox(self):
         master_inbox_path = os.path.join(self.TEST_DIR, "master_inbox")
         container_inboxes_path = os.path.join(self.TEST_DIR, "container_inboxes")

--- a/bakula/events/orchestrator.py
+++ b/bakula/events/orchestrator.py
@@ -55,11 +55,20 @@ class Orchestrator:
     # that has passed its timer
     def __process_pending(self):
         while (True):
+            for_process = []
             for topic in self.pending:
                 for container in self.pending[topic]:
                     if self.__get_current_time_in_seconds() > self.pending[topic][container]:
-                        # It's go time!
-                        self.__process(topic, container)
+                        # It's go time! Pop into array so we can run after the loop
+                        # Otherwise modiying the dictionary during runtime is bad (item is
+                        # removed from pending immediately upon start of processing)
+                        for_process.append({ "topic": topic, "container": container })
+
+            # Iterate the array and run the things inside
+            for process in for_process:
+                self.__process(process["topic"], process["container"])
+                
+            del for_process[:]
             try:
                 sleep(TIMER_INTERVAL)
             except KeyboardInterrupt:

--- a/bakula/events/orchestrator.py
+++ b/bakula/events/orchestrator.py
@@ -27,7 +27,7 @@ TIMER_INTERVAL = 10.0
 # This class handles the event handling of the inboxer and, when a threshold is hit,
 # it promotes the appropriate files as an inbox or a docker container then fires the
 # docker container.
-class Orchestrator:
+class Orchestrator(object):
     def __init__(self, inboxer=Inboxer(), docker_agent=None):
         self.inboxer = inboxer
         self.inboxer.on("received", self.__handle_inbox_received_event)
@@ -67,7 +67,7 @@ class Orchestrator:
             # Iterate the array and run the things inside
             for process in for_process:
                 self.__process(process["topic"], process["container"])
-                
+
             del for_process[:]
             try:
                 sleep(TIMER_INTERVAL)

--- a/bakula/events/orchestrator.py
+++ b/bakula/events/orchestrator.py
@@ -16,50 +16,98 @@
 #   under the License.
 from bakula.events.inboxer import Inboxer
 from bakula.docker.dockeragent import DockerAgent
+from threading import Timer
 from bakula.models import Registration, resolve_query
-import uuid
+from calendar import timegm
+from time import gmtime
+from uuid import uuid4
+
+TIMER_INTERVAL = 10.0
 
 # This class handles the event handling of the inboxer and, when a threshold is hit,
 # it promotes the appropriate files as an inbox or a docker container then fires the
 # docker container.
 class Orchestrator:
     def __init__(self, inboxer=Inboxer(), docker_agent=None):
-         self.inboxer = inboxer
-         self.inboxer.on("received", self.__handle_inbox_received_event)
-         self.docker_agent = docker_agent
-         if self.docker_agent is None:
-             self.docker_agent = DockerAgent()
+        self.inboxer = inboxer
+        self.inboxer.on("received", self.__handle_inbox_received_event)
+        self.docker_agent = docker_agent
+        if self.docker_agent is None:
+            self.docker_agent = DockerAgent()
+
+        # Setup pending queue
+        self.pending = { }
+        self.__process_pending()
 
     # Get listing of registered containers filtered by topic
     def __get_registered_containers(self, topic):
-        return Registration.select().where(Registration.topic == topic)
+        return resolve_query(Registration.select().where(Registration.topic == topic))
+
+    # Clear the pending queue of a specific topic
+    def __clear_pending(self, topic, container_name):
+        if topic is not None and topic in self.pending:
+            if container_name is not None and container_name in self.pending[topic]:
+                del self.pending[topic][container_name]
+
+    # Iterate through the self.pending queue and act on anything queued
+    # that has passed its timer
+    def __process_pending(self):
+        for topic in self.pending:
+            for container in self.pending[topic]:
+                if self.__get_current_time_in_seconds() > self.pending[topic][container]:
+                    # It's go time!
+                    self.__process(topic, container)
+        self.interval_timer = Timer(TIMER_INTERVAL, self.__process_pending)
+        self.interval_timer.start()
+
+    def __process(self, topic, container_name):
+        self.__clear_pending(topic, container_name) # Clear the topic so this isn't hit multiple times
+
+        # Promote all files in the inbox, delineated by topic, to a directory for
+        # a container to mount; returns a list of created inboxes
+        container_inboxes = self.inboxer.promote_to_container_inbox(topic, str(uuid4()))
+
+        if container_inboxes is None or len(container_inboxes) == 0:
+            print "There are no container inboxes available for the event run; did something weird happen?"
+            return None
+
+        for container_inbox in container_inboxes:
+            # container_inbox is the path inboxer promoted to be mounted in the docker container
+            self.docker_agent.pull(container_name)
+            self.docker_agent.start_container(host_inbox=container_inbox, image_name=container_name)
+
+    # Get the current time, in seconds, since epoch
+    def __get_current_time_in_seconds(self):
+        return timegm(gmtime())
 
     # This event handler is executed every time a file is put into the master inbox
     # The data argument includes a property specify the topic that was appended to
     def __handle_inbox_received_event(self, data):
+        topic = data["topic"]
+        count = self.inboxer.get_inbox_count(topic)
         # Get a list of all files in the inbox delineated by the topic in the event
-        inbox_list = self.inboxer.get_inbox_list(data["topic"])
+        inbox_list = self.inboxer.get_inbox_list(topic)
 
-        # Are there enough items in the inbox to trigger the threshold?
-        if len(inbox_list) >= 1: # This is just a temporary threshold
-            # Promote all files in the inbox, delineated by topic, to a directory for
-            # a container to mount; returns a list of created inboxes
-            container_infos = self.__get_registered_containers(data["topic"])
+        # If there are no items in the inbox then there is literally nothing to do
+        if count == 0:
+            return None
 
-            if container_infos is None:
-                print "Container for topic not found; doing nothing..."
-                return None
+        container_infos = self.__get_registered_containers(data["topic"])
 
-            container_inboxes = self.inboxer.promote_to_container_inbox(data["topic"], str(uuid.uuid4()))
+        # We have no container infos! :(
+        if container_infos is None:
+            print "Container for topic not found; doing nothing..."
+            return None
 
-            if container_inboxes is None or len(container_inboxes) == 0:
-                print "There are no container inboxes available for the event run; did something weird happen?"
-                return None
-
-            for container_inbox in container_inboxes:
-                for container_info in container_infos:
-                    # container_inbox is the path inboxer promoted to be mounted in the docker container
-                    # container_info is the result from the database that specifies the container name to execute
-                    image_name = container_info.container
-                    self.docker_agent.pull(image_name)
-                    self.docker_agent.start_container(host_inbox=container_inbox, image_name=image_name)
+        for container_info in container_infos:
+            container = container_info["container"]
+            # If the count has reached the threshold then it's time to execute!
+            threshold = container_info["threshold"] if container_info["threshold"] is not None else 1
+            if count >= threshold:
+                self.__process(topic, container)
+            else:
+                # We haven't hit the threshold so we need to start counting down
+                # Set the current time
+                if topic not in self.pending:
+                    self.pending[topic] = {}
+                self.pending[topic][container] = (self.__get_current_time_in_seconds() + container_info["timeout"])


### PR DESCRIPTION
This adds proper handling of the threshold and timeout settings per registration. The event loop in the orchestrator runs every 10 seconds, checks for new, pending items in the inbox that didn't meet the threshold number. If they hit the timeout count it then executes them and removes them from pending. Possible improvement would be making the loop timing dynamic so it runs when the next timeout occurs.

@sapanshah @ericjperry 