### PR TITLE
Fixed container inbox paths returned from inboxer

### DIFF
--- a/bakula/events/inboxer.py
+++ b/bakula/events/inboxer.py
@@ -158,6 +158,7 @@ class Inboxer(object):
                     self.container_inboxes_path, containerid)
                 if not os.path.exists(container_inbox_path):
                     os.makedirs(container_inbox_path)
+                container_inboxes.append(container_inbox_path)
 
                 for fname in promotees:
                     try:
@@ -166,7 +167,6 @@ class Inboxer(object):
                                                 fname)
                         destination = os.path.join(container_inbox_path, fname)
                         os.link(fullpath, destination)
-                        container_inboxes.append(destination)
                     except Exception as ex:
                         print "Generating hard links failed due to %s" % ex
                         return None


### PR DESCRIPTION
There was a small issue in the inboxer where the 'inbox' paths returned were the paths to the actual file names rather than the directories (which the container expects).

@KrisSiegel @sapanshah 